### PR TITLE
Updated Readme to include installation instructions for Bower

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,11 @@ Dependencies
 - [iScroll 4.x](https://github.com/cubiq/iscroll)   Version 4.2.x Recommended
 
 
+Installation
+------------
+ - **Bower**:
+ Install the package by adding `ng-iScroll` to your `bower.json` file.
+
 Reporting Issues
 -------------
 - Issues can be reported at the Github project.


### PR DESCRIPTION
The name (ng-iScroller) is not compatible with the bower package name. Therefore a hind would be great how the package is called.