### PR TITLE
iScroll instance should be destroyed when the scope itself is destroyed.

### DIFF
--- a/src/ng-iscroll.js
+++ b/src/ng-iscroll.js
@@ -93,13 +93,19 @@ angular.module('ng-iscroll', []).directive('ngIscroll', function ()
                 setTimeout(setScroll, ngiScroll_timeout);
             });
 
-			// add ng-iscroll-refresher for watching dynamic content inside iscroll
-			if(attr.ngIscrollRefresher !== undefined) {
-				scope.$watch(attr.ngIscrollRefresher, function ()
-				{
-					if(scope.$parent.myScroll[scroll_key] !== undefined) scope.$parent.myScroll[scroll_key].refresh();
-				});
-			}
+		// add ng-iscroll-refresher for watching dynamic content inside iscroll
+		if(attr.ngIscrollRefresher !== undefined) {
+			scope.$watch(attr.ngIscrollRefresher, function ()
+			{
+				if(scope.$parent.myScroll[scroll_key] !== undefined) scope.$parent.myScroll[scroll_key].refresh();
+			});
+		}
+		
+		// destroy the iscroll instance if we are moving away from a state to another
+		// the DOM has changed and he only instance is not necessary any more
+		scope.$on('$destroy', function () {
+			scope.$parent.myScroll[scroll_key].destory();	
+		});
         }
     };
 });


### PR DESCRIPTION
In large application with many states and multiple iScroll instances, while switching states the DOM changes. Thus it makes sense to destroy the iScoll instance when the $scope is destroyed.

```scope.$parent.myScroll[scroll_key]``` will keep on pointing to that instance of iScroll even though the associated DOM has been destroyed. ```scope.$parent.myScroll[scroll_key]``` reference will only be update to a new instance of iScroll when the state is visited again. Only now the old instance reference is detached and next GC will clean the associated memory.